### PR TITLE
fix: universal links iOS

### DIFF
--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -10,6 +10,7 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:appfor.it</string>
 		<string>webcredentials:appfor.it</string>
 	</array>
 </dict>


### PR DESCRIPTION
The associated domain was previously only configured for credentials and not for app links...