### PR TITLE
chore: release android app to internal automatically

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,6 +86,6 @@ jobs:
           packageName: is.giorgio.app.parousia
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           track: internal
-          status: draft
+          status: completed
           mappingFile: build/app/outputs/mapping/release/mapping.txt
           debugSymbols: build/app/intermediates/merged_native_libs/release/out/lib


### PR DESCRIPTION
DO NOT MERGE UNTIL ANDROID ALPHA IS RELEASED