### PR TITLE
fix: navigation redirect

### DIFF
--- a/lib/presentation/screens/auth.dart
+++ b/lib/presentation/screens/auth.dart
@@ -11,8 +11,6 @@ class AuthScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    onSuccess(session) => HomeScreenRoute().go(context);
-
     final config = ConfigService().config;
 
     return Scaffold(
@@ -25,8 +23,7 @@ class AuthScreen extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 16),
         child: Column(children: [
           SupaPasswordAuth(
-            onSignInComplete: onSuccess,
-            onSignUpComplete: onSuccess,
+            redirectTo: _getRedirectUrl(),
           ),
           Divider(height: 64),
           SupaSocialsAuth(
@@ -37,7 +34,7 @@ class AuthScreen extends StatelessWidget {
             ),
             enableNativeAppleAuth: true,
             redirectUrl: _getRedirectUrl(),
-            onSuccess: onSuccess,
+            onSuccess: (session) => HomeScreenRoute().go(context),
           ),
         ]),
       ),
@@ -52,6 +49,7 @@ class AuthScreen extends StatelessWidget {
 
     final currentUrl = html.window.location.href;
     final uri = Uri.parse(currentUrl);
-    return '${uri.scheme}://${uri.host}${uri.port != 80 && uri.port != 443 ? ':${uri.port}' : ''}';
+    final redirectUrl = Uri(scheme: uri.scheme, host: uri.host, port: uri.port);
+    return redirectUrl.toString();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -720,10 +720,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "8faba09ba361d4b246dc0a17cb4289b3324c2b9f6db7b3d457ee69106a86bd32"
+      sha256: fa8141602fde3f7e2f81dbf043613eb44dfa325fa0bcf93c0f142c9f7a2c193e
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+17"
+    version: "0.8.12+18"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1444,7 +1444,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "8d1f7eac39b386c26159ca022d7eb817f27e7a68"
+      resolved-ref: a20c7ecd610de227eb6cce469fa877e3b1c4556c
       url: "https://github.com/sealambda/flutter-auth-ui"
     source: git
     version: "0.5.4"
@@ -1732,10 +1732,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "84ba388638ed7a8cb3445a320c8273136ab2631cd5f2c57888335504ddab1bc2"
+      sha256: "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69"
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0"
+    version: "5.9.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -42,7 +42,7 @@ file_size_limit = "50MiB"
 # in emails.
 site_url = "https://appfor.it"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://localhost:3000"]
+additional_redirect_urls = ["http://localhost:*"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one
 # week).
 jwt_expiry = 3600
@@ -56,6 +56,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
+# TODO Setting this to true will break our tests, so we need to fix that first.
 enable_confirmations = false
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,


### PR DESCRIPTION
I'm not sure whether this may solve #88 - however - at least it makes it possible to test the email redirect locally via inmonitor[^1]

I also got rid of the `onSignInComplete` and `onSignUpComplete` callbacks as they cased some kind of race conditions on sign up, and they weren't needed anyway because of the implicit redirect we have with epics.

[^1]: http://localhost:54324/