### PR TITLE
fix: custom scheme for email auth redirect

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,13 +27,20 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
 
-            <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
+            <meta-data android:name="flutter_deeplinking_enabled" android:value="true"/>
             <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="http" android:host="appfor.it" />
-                <data android:scheme="https" />
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="http" android:host="appfor.it"/>
+                <data android:scheme="https"/>
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="appforit"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -63,6 +63,7 @@
 				<key>CFBundleURLSchemes</key>
 				<array>
 					<string>com.googleusercontent.apps.655087059227-o10vdnfsvnkl9ct8isg8db3j74s0rfur</string>
+                    <string>appforit</string>
 				</array>
 			</dict>
 		</array>

--- a/lib/epics/invites.dart
+++ b/lib/epics/invites.dart
@@ -52,7 +52,8 @@ Epic<AppState> _createGetInvitesForMemberEpic(InvitesRepository invites) {
 Epic<AppState> _createUseDeeplinkInviteCodeEpic(InvitesRepository invites) {
   return (Stream<dynamic> actions, EpicStore<AppState> store) => actions
           .whereType<HandleDeeplinkAction>()
-          .where((action) => action.paths.first == 'join')
+          .where((action) =>
+              action.paths.isNotEmpty && action.paths.first == 'join')
           .asyncMap((action) {
         final code = action.paths.last;
         return invites

--- a/lib/presentation/screens/auth.dart
+++ b/lib/presentation/screens/auth.dart
@@ -45,7 +45,7 @@ class AuthScreen extends StatelessWidget {
   /// This is needed to handle different ports
   /// when launching on localhost.
   String? _getRedirectUrl() {
-    if (!kIsWeb) return null;
+    if (!kIsWeb) return 'appforit://auth-callback';
 
     final currentUrl = html.window.location.href;
     final uri = Uri.parse(currentUrl);

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -42,7 +42,7 @@ file_size_limit = "50MiB"
 # in emails.
 site_url = "https://appfor.it"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["http://localhost:*"]
+additional_redirect_urls = ["http://localhost:*", "appforit://auth-callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one
 # week).
 jwt_expiry = 3600


### PR DESCRIPTION
Previously we were always using https for the email auth redirect link/

However, some email clients would then open the browser instead of the mobile app, effectively breaking the flow.

Fixes #70 