### PR TITLE
chore: rename ci jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,8 @@ on:
       - main
 
 jobs:
-  flutter:
+  build:
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
     steps:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  flutter:
+  verify:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false && startsWith(github.event.pull_request.title, 'Draft') == false
     steps:


### PR DESCRIPTION
## Summary

Rename jobs, so we can use them in rules set.

## Impact

- [ ] App
- [ ] Supabase functions
- [ ] Supabase migration
- [X] CI / GitHub
- [ ] `pubspec.yaml`

## Testing steps

None.

## Open points

None.
