### PR TITLE
fix: wrong sentry release on web

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
           # This should ensure that the web build has the same settings as mobile apps to configure Sentry consistently
           SENTRY_RELEASE: "is.giorgio.app.parousia@${{ steps.parse_pubspec.outputs.pubspec_version }}+${{ github.run_number }}"
           SENTRY_DIST: ${{ github.run_number }}
-        run: dart run peanut
+        run: dart run peanut --dart-define="SENTRY_RELEASE=$SENTRY_RELEASE" --dart-define="SENTRY_DIST=$SENTRY_DIST"
 
       - name: Push gh-pages
         run: git push origin gh-pages


### PR DESCRIPTION
## Summary

- The sentry env variables are not being taken by the web version.

## Impact

- [ ] App
- [ ] Supabase functions
- [ ] Supabase migration
- [X] CI / GitHub
- [ ] `pubspec.yaml`

## Testing steps

None, just deploy and see if it works.
