### PR TITLE
fix: mismatch yes replies between summary and detailed view

### DIFF
--- a/lib/selectors/schedules.dart
+++ b/lib/selectors/schedules.dart
@@ -11,6 +11,7 @@ ScheduleInstanceSummary repliesForScheduleInstance({
   required Schedule schedule,
   required DateTime startDate,
   required DateTime endDate,
+  required Iterable<Member> members,
   Iterable<DefaultRule>? defaultRules,
   Iterable<Reply>? replies,
   String? targetMemberId,
@@ -19,6 +20,7 @@ ScheduleInstanceSummary repliesForScheduleInstance({
   final memberReplies = <String, ReplyOptions>{};
   final memberDefaultReplies = <String, ReplyOptions>{};
   final memberDefaultRules = <String, DefaultRule>{};
+  final membersSet = members.map((m) => m.id).toSet();
 
   ReplyOptions? myReply;
   ReplyOptions? myDefaultReply;
@@ -44,7 +46,9 @@ ScheduleInstanceSummary repliesForScheduleInstance({
       final isSameDay = e.copyWith(isUtc: true).isAtSameMomentAs(instanceDate);
       final isSameSchedule = defaultRule.scheduleId == schedule.id;
 
-      if (isSameDay && isSameSchedule) {
+      if (isSameDay &&
+          isSameSchedule &&
+          membersSet.contains(defaultRule.memberId)) {
         if (defaultRule.memberId == targetMemberId) {
           myDefaultReply = defaultRule.selectedOption;
         } else {
@@ -62,7 +66,7 @@ ScheduleInstanceSummary repliesForScheduleInstance({
           .copyWith(isUtc: true)
           .isAtSameMomentAs(instanceDate);
       final isSameSchedule = reply.scheduleId == schedule.id;
-      if (isSameDay && isSameSchedule) {
+      if (isSameDay && isSameSchedule && membersSet.contains(reply.memberId)) {
         if (reply.memberId == targetMemberId) {
           myReply = reply.selectedOption;
         } else {
@@ -96,6 +100,7 @@ Iterable<ScheduleInstanceSummary> getScheduleInstances({
   required Schedule schedule,
   required DateTime startDate,
   required DateTime endDate,
+  required Iterable<Member> members,
   Iterable<DefaultRule>? defaultRules,
   Iterable<Reply>? replies,
   String? targetMemberId,
@@ -117,6 +122,7 @@ Iterable<ScheduleInstanceSummary> getScheduleInstances({
           replies: replies,
           startDate: after,
           endDate: endDate,
+          members: members,
           targetMemberId: targetMemberId,
         ),
       );

--- a/lib/selectors/selectors.dart
+++ b/lib/selectors/selectors.dart
@@ -53,19 +53,21 @@ final selectReplies = createSelector3(
 // This one is simpler because it doesn't need to group the members by their reply,
 // however, by doing so, there is a mismatch as some replies may still be counted,
 // even if a member is no longer part of the group.
-final selectScheduleInstancesForSelectedDate = createSelector5(
+final selectScheduleInstancesForSelectedDate = createSelector6(
     selectedDateRangeSelector,
     selectMyMember,
     selectSchedules,
     selectDefaultRules,
     selectReplies,
-    (range, myMember, schedules, defaultRules, replies) =>
+    groupMembersSelector,
+    (range, myMember, schedules, defaultRules, replies, members) =>
         schedules.expand((schedule) => getScheduleInstances(
               schedule: schedule,
               defaultRules: defaultRules,
-              replies: replies,
               startDate: range.start,
               endDate: range.end,
+              replies: replies,
+              members: members,
               targetMemberId: myMember?.$1.id,
             )));
 

--- a/lib/selectors/selectors.dart
+++ b/lib/selectors/selectors.dart
@@ -48,6 +48,11 @@ final selectReplies = createSelector3(
     (replies, scheduleIds, range) => replies.where((r) =>
         scheduleIds.contains(r.scheduleId) && range.contains(r.instanceDate)));
 
+// TODO This selector and selectScheduleInstanceForDate are very similar,
+// however, this one is used in the list view and the other in the detail view.
+// This one is simpler because it doesn't need to group the members by their reply,
+// however, by doing so, there is a mismatch as some replies may still be counted,
+// even if a member is no longer part of the group.
 final selectScheduleInstancesForSelectedDate = createSelector5(
     selectedDateRangeSelector,
     selectMyMember,

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -7,6 +7,8 @@ PODS:
   - AppAuth/Core (1.7.6)
   - AppAuth/ExternalUserAgent (1.7.6):
     - AppAuth/Core
+  - device_info_plus (0.0.1):
+    - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
@@ -39,7 +41,7 @@ PODS:
   - posthog_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - PostHog (~> 3.0)
+    - PostHog (= 3.18.0)
   - Sentry/HybridSDK (8.42.0)
   - sentry_flutter (8.12.0):
     - Flutter
@@ -57,6 +59,7 @@ PODS:
 
 DEPENDENCIES:
   - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
+  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
@@ -82,6 +85,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   app_links:
     :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
+  device_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   FlutterMacOS:
@@ -110,6 +115,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_links: 9028728e32c83a0831d9db8cf91c526d16cc5468
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
+  device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
   file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   google_sign_in_ios: 0ab078e60da6dfe23cbc55c83502b52bba1aad63
@@ -120,7 +126,7 @@ SPEC CHECKSUMS:
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   PostHog: 6ce18b57e7de83868707dec4a0c35ebbc866e88b
-  posthog_flutter: 37053225347313fb5385539b300a8237fae24e34
+  posthog_flutter: c708a6cdd2557be394f3d0e0533c94a68c9ee71d
   Sentry: 38ed8bf38eab5812787274bf591e528074c19e02
   sentry_flutter: a72ca0eb6e78335db7c4ddcddd1b9f6c8ed5b764
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc

--- a/test/schedules_test.dart
+++ b/test/schedules_test.dart
@@ -80,10 +80,16 @@ void main() {
             selectedOption: ReplyOptions.yes),
       ];
 
+      final members = [
+        Member(id: member1Id, groupId: groupId, role: GroupRoles.member),
+        Member(id: member2Id, groupId: groupId, role: GroupRoles.member),
+      ];
+
       final result = getScheduleInstances(
         schedule: dailySchedule,
         defaultRules: defaultRules,
         replies: replies,
+        members: members,
         startDate: startDate.subtract(const Duration(days: 10)),
         endDate: endDate,
         targetMemberId: member1Id,

--- a/test/selectors_test.dart
+++ b/test/selectors_test.dart
@@ -14,7 +14,7 @@ void main() {
     test('mismatch between detail and list view in yes count', () {
       final uuid = Uuid();
 
-      final date = DateTime(2022, 1, 1).toUtc();
+      final date = DateTime.utc(2022, 1, 1, 12);
 
       final authUser = User(
         id: uuid.v4(),

--- a/test/selectors_test.dart
+++ b/test/selectors_test.dart
@@ -1,0 +1,124 @@
+import 'dart:math';
+
+import 'package:parousia/models/models.dart';
+import 'package:parousia/selectors/selectors.dart';
+import 'package:parousia/state/state.dart';
+import 'package:parousia/util/recurrence_rules.dart';
+import 'package:redux_entity/redux_entity.dart';
+import 'package:supabase/supabase.dart' show User;
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+void main() {
+  group('selectors', () {
+    test('mismatch between detail and list view in yes count', () {
+      final uuid = Uuid();
+
+      final date = DateTime(2022, 1, 1).toUtc();
+
+      final authUser = User(
+        id: uuid.v4(),
+        appMetadata: {},
+        userMetadata: null,
+        aud: 'aud',
+        createdAt: DateTime.now().toIso8601String(),
+      );
+
+      final profiles = [
+        Profile(
+          id: authUser.id,
+          displayName: 'current user',
+        ),
+        for (var i = 0; i < 10; i++)
+          Profile(
+            id: uuid.v4(),
+            displayName: 'user $i',
+          ),
+      ];
+
+      final group = Group(
+        id: 'group',
+        displayName: 'group',
+      );
+
+      Member createMember(Profile profile) => Member(
+            id: uuid.v7(),
+            groupId: group.id,
+            profileId: profile.id,
+            role: GroupRoles.member,
+          );
+      final members = [
+        for (final profile in profiles) createMember(profile),
+      ];
+
+      final schedules = [
+        Schedule(
+          id: uuid.v7(),
+          groupId: group.id,
+          displayName: 'schedule 1',
+          startDate: date,
+          recurrenceRule: CommonRecurrenceRules.daily,
+        ),
+      ];
+
+      Reply createReply(Member member, Schedule schedule, DateTime date) =>
+          Reply(
+            memberId: member.id,
+            scheduleId: schedule.id,
+            instanceDate: date,
+            selectedOption:
+                Random().nextBool() ? ReplyOptions.yes : ReplyOptions.no,
+          );
+      final replies = [
+        for (final schedule in schedules) ...[
+          // create a reply for a member that no longer exists
+          Reply(
+            memberId: 'non-existent',
+            scheduleId: schedule.id,
+            instanceDate: date,
+            selectedOption: ReplyOptions.yes,
+          ),
+          for (final member in members) createReply(member, schedule, date),
+        ]
+      ];
+
+      final state = AppState(
+        selectedDate: date,
+        auth: AuthState(status: AuthStatus.authenticated, user: authUser),
+        profiles: RemoteEntityState<Profile>(entities: {
+          for (final profile in profiles) profile.id: profile,
+        }),
+        groups: RemoteEntityState<Group>(entities: {group.id: group}),
+        members: RemoteEntityState<Member>(entities: {
+          for (final member in members) member.id: member,
+        }),
+        schedules: RemoteEntityState<Schedule>(entities: {
+          for (final schedule in schedules) schedule.id: schedule,
+        }),
+        defaultRules: RemoteEntityState<DefaultRule>(entities: {
+          // TODO Does it happen with default rules?
+        }),
+        replies: RemoteEntityState<Reply>(entities: {
+          for (final reply in replies)
+            "${reply.memberId}-${reply.scheduleId}-${reply.instanceDate}":
+                reply,
+        }),
+        selectedGroupId: group.id,
+        // selectedScheduleId: // TODO
+      );
+
+      final result = selectScheduleInstancesForSelectedDate(state);
+
+      for (final instance in result) {
+        final state2 = state.copyWith(selectedScheduleId: instance.scheduleId);
+        final instance2 = selectScheduleInstanceForDate(state2);
+
+        expect(
+            instance2?.repliesGroups
+                .firstWhere((e) => e.reply == ReplyOptions.yes)
+                .count,
+            equals(instance.yesCount));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Not my proudest bug fix, but it works... The selectors would need some love, but as we said before, we are probably going to get rid of Redux anyway.

## Impact

- [x] App
- [ ] Supabase functions
- [ ] Supabase migration
- [ ] CI / GitHub
- [ ] `pubspec.yaml`

## Testing steps

To trigger the bug, you need some replies (or default rules), with a yes reply. Then, you have to remove the members who had those replies.
