### PR TITLE
Fix Xcode Cloud archive: commit SPM Package.resolved

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -12,7 +12,12 @@
 Icon?
 **/Pods/
 **/.symlinks/
-**/xcshareddata/swiftpm/
+# Ignore SPM workspace state but keep the workspace-level Package.resolved:
+# Xcode Cloud runs with automatic dependency resolution disabled and requires
+# it in the repository. The xcodeproj-level copy stays ignored (local artifact).
+# (`/*` not `/` — git cannot re-include files inside a fully ignored directory.)
+**/xcshareddata/swiftpm/*
+!Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
 profile
 xcuserdata
 **/.generated/

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,42 +1,22 @@
 PODS:
   - Flutter (1.0.0)
-  - flutter_contacts (0.0.1):
-    - Flutter
-  - PostHog (3.62.5)
-  - posthog_flutter (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - PostHog (< 4.0.0, >= 3.32.0)
   - sign_in_with_apple (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - flutter_contacts (from `.symlinks/plugins/flutter_contacts/ios`)
-  - posthog_flutter (from `.symlinks/plugins/posthog_flutter/ios`)
   - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
-
-SPEC REPOS:
-  trunk:
-    - PostHog
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  flutter_contacts:
-    :path: ".symlinks/plugins/flutter_contacts/ios"
-  posthog_flutter:
-    :path: ".symlinks/plugins/posthog_flutter/ios"
   sign_in_with_apple:
     :path: ".symlinks/plugins/sign_in_with_apple/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_contacts: 5383945387e7ca37cf963d4be57c21f2fc15ca9f
-  PostHog: 3ef88b8cec6e42fc3dbffc036e49cded2b82d5e5
-  posthog_flutter: 9535ac2d4ab65ccb9ace3886dcc0b3105198bad5
   sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
 
 PODFILE CHECKSUM: 4c438addb11b6da45ed7ae408823d68256222460
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,95 @@
+{
+  "pins" : [
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "bb4002485ff867768dec13bf904a2ddb050bd1b1",
+        "version" : "11.3.0"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "a7caeda164dc5108bf4649472b28a5af65dc6f33",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS.git",
+      "state" : {
+        "revision" : "08d8dcecafb575f98879ffdbb8302c1b9ad65d19",
+        "version" : "9.2.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "c46e5f8b7c23265f17c24ca7f9fa1b13ded7a822",
+        "version" : "8.1.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "56e0ccf09a6dd29dc7e68bdf729598240ca8aa16",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios",
+      "state" : {
+        "revision" : "f271e65b58ad5286df38ce4d759ceb6f8db13c5b",
+        "version" : "3.69.3"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "f196cbb98e0388381d57908f2f5a9bdc385cde68",
+        "version" : "8.58.4"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
## Summary

Fixes the Xcode Cloud iOS archive failure after #224:

> a resolved file is required when automatic dependency resolution is disabled and should be placed at /Volumes/workspace/repository/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved

Root cause: `ios/.gitignore` excluded the entire `**/xcshareddata/swiftpm/` directory, so `Package.resolved` was never in the repo. Xcode Cloud archives with automatic dependency resolution disabled and requires it. The dependency upgrades changed the SPM package set (posthog-ios, sentry-cocoa, …), turning the latent gap into a hard failure.

- Commit the workspace-level `Package.resolved` (95 lines of pins) and scope the gitignore exception to exactly that file — the `xcodeproj`-level duplicate stays ignored as a local artifact.
- Refresh `ios/Podfile.lock` for the post-upgrade plugin set: passkeys is gone entirely and several plugins moved to SPM; only 2 CocoaPods remain (`flutter_contacts` → now SPM, etc.).

Going forward: whenever iOS plugin dependencies change, `Package.resolved` must be regenerated (open the workspace or `xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme Runner`) and committed — CI doesn't build iOS, so Xcode Cloud is the first thing that notices.

## Test plan
- [x] `pod install --repo-update` from clean CocoaPods
- [x] `xcodebuild -resolvePackageDependencies` regenerates the committed resolution
- [x] `flutter build ios --no-codesign` succeeds from clean DerivedData (46.3MB Runner.app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)