### PR TITLE
fix(aso): strip emoji from App Store descriptions

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,6 +31,10 @@ App Store side must use deliver's names (`it`, not `it-IT` — deliver errors ou
 listing the valid names if you get one wrong). The app itself ships
 en/de/es/fr/it (`lib/l10n/`) — keep listing locales in step.
 
+**No emoji in App Store text** — the ASC API rejects them in `description` (and
+friends) with "invalid characters". Play descriptions may use emoji, so the
+`android/` and `ios/` copies of the same text intentionally differ there.
+
 ## Release notes flow
 
 `android/<locale>/changelogs/default.txt` is the canonical user-facing note for

--- a/fastlane/metadata/ios/de-DE/description.txt
+++ b/fastlane/metadata/ios/de-DE/description.txt
@@ -3,14 +3,14 @@ Genug von endlosen „Wann können alle?“-Nachrichten? GRUP ist der gemeinsame
 Erstelle eine Gruppe, teile den Kalender, plane ein Event und sammle Zu- und Absagen in Sekunden. Perfekt für Familien mit vollem Terminkalender, Paare, die ihre Pläne abstimmen, und Freundeskreise, die sich öfter sehen wollen.
 
 WARUM GRUP?
-• 🗓️ Gemeinsamer Kalender — alle Pläne deiner Gruppe an einem Ort
-• ✅ Zusagen auf einen Blick — sieh sofort, wer dabei ist und wer nicht
-• 🔁 Wiederkehrende Termine — wöchentliches Essen, Training, Spieleabend: einmal planen
-• ⭐ Standardantworten — „Dienstags bin ich immer dabei“: einmal antworten, GRUP übernimmt den Rest
-• 👥 Mehrere Gruppen — Familie, Freunde, Team, Verein: alles organisiert
-• 📨 Einfache Einladungen — hol alle mit einer Einladung dazu
-• 🔔 Benachrichtigungen — bleib auf dem Laufenden, wenn sich Pläne ändern
-• 🆓 Kostenlos — keine versteckten Kosten, keine Überraschungen
+• Gemeinsamer Kalender — alle Pläne deiner Gruppe an einem Ort
+• Zusagen auf einen Blick — sieh sofort, wer dabei ist und wer nicht
+• Wiederkehrende Termine — wöchentliches Essen, Training, Spieleabend: einmal planen
+• Standardantworten — „Dienstags bin ich immer dabei“: einmal antworten, GRUP übernimmt den Rest
+• Mehrere Gruppen — Familie, Freunde, Team, Verein: alles organisiert
+• Einfache Einladungen — hol alle mit einer Einladung dazu
+• Benachrichtigungen — bleib auf dem Laufenden, wenn sich Pläne ändern
+• Kostenlos — keine versteckten Kosten, keine Überraschungen
 
 GEMACHT FÜR
 • Familien — Treffen, Essen und Alltagsorganisation

--- a/fastlane/metadata/ios/en-GB/description.txt
+++ b/fastlane/metadata/ios/en-GB/description.txt
@@ -3,14 +3,14 @@ Tired of “when works for everyone?” threads that go nowhere? GRUP is the sha
 Create a group, share the calendar, plan an event and collect RSVPs in seconds. Perfect for families juggling busy weeks, couples keeping their plans in sync, and friend groups that actually want to see each other more.
 
 WHY GRUP?
-• 🗓️ Shared calendar — all your group’s plans in one place
-• ✅ RSVPs at a glance — instantly see who’s in and who’s out
-• 🔁 Recurring events — weekly dinners, training, game night: schedule once
-• ⭐ Default answers — “I’m always in on Tuesdays”: reply once, GRUP fills in the rest
-• 👥 Multiple groups — family, friends, team, club: keep them all organised
-• 📨 Easy invites — bring everyone in with a simple invite
-• 🔔 Notifications — stay up to date when plans change
-• 🆓 Free — no hidden costs or surprises
+• Shared calendar — all your group’s plans in one place
+• RSVPs at a glance — instantly see who’s in and who’s out
+• Recurring events — weekly dinners, training, game night: schedule once
+• Default answers — “I’m always in on Tuesdays”: reply once, GRUP fills in the rest
+• Multiple groups — family, friends, team, club: keep them all organised
+• Easy invites — bring everyone in with a simple invite
+• Notifications — stay up to date when plans change
+• Free — no hidden costs or surprises
 
 MADE FOR
 • Families — gatherings, dinners and everyday organisation

--- a/fastlane/metadata/ios/es-ES/description.txt
+++ b/fastlane/metadata/ios/es-ES/description.txt
@@ -3,14 +3,14 @@
 Crea un grupo, comparte el calendario, planifica un evento y recoge confirmaciones en segundos. Perfecto para familias con semanas ajetreadas, parejas que quieren sincronizar sus planes y grupos de amigos que de verdad quieren verse más.
 
 ¿POR QUÉ GRUP?
-• 🗓️ Calendario compartido — todos los planes de tu grupo en un solo lugar
-• ✅ Confirmaciones de un vistazo — ve al instante quién viene y quién no
-• 🔁 Eventos recurrentes — cena semanal, entrenamiento, noche de juegos: prográmalo una vez
-• ⭐ Respuestas predeterminadas — «los martes siempre voy»: responde una vez y GRUP hace el resto
-• 👥 Varios grupos — familia, amigos, equipo, club: todo organizado
-• 📨 Invitaciones fáciles — suma a todos con una simple invitación
-• 🔔 Notificaciones — entérate cuando los planes cambien
-• 🆓 Gratis — sin costes ocultos ni sorpresas
+• Calendario compartido — todos los planes de tu grupo en un solo lugar
+• Confirmaciones de un vistazo — ve al instante quién viene y quién no
+• Eventos recurrentes — cena semanal, entrenamiento, noche de juegos: prográmalo una vez
+• Respuestas predeterminadas — «los martes siempre voy»: responde una vez y GRUP hace el resto
+• Varios grupos — familia, amigos, equipo, club: todo organizado
+• Invitaciones fáciles — suma a todos con una simple invitación
+• Notificaciones — entérate cuando los planes cambien
+• Gratis — sin costes ocultos ni sorpresas
 
 PENSADO PARA
 • Familias — reuniones, cenas y la organización del día a día

--- a/fastlane/metadata/ios/fr-FR/description.txt
+++ b/fastlane/metadata/ios/fr-FR/description.txt
@@ -3,14 +3,14 @@ Marre des fils de discussion interminables « quand est-ce que ça arrange tout 
 Créez un groupe, partagez le calendrier, planifiez un événement et récoltez les RSVP en quelques secondes. Parfait pour les familles aux semaines chargées, les couples qui synchronisent leurs plannings et les bandes d’amis qui veulent vraiment se voir plus souvent.
 
 POURQUOI GRUP ?
-• 🗓️ Calendrier partagé — tous les plans de votre groupe au même endroit
-• ✅ RSVP en un coup d’œil — voyez immédiatement qui vient et qui ne vient pas
-• 🔁 Événements récurrents — dîner hebdomadaire, entraînement, soirée jeux : planifiez une seule fois
-• ⭐ Réponses par défaut — « le mardi, je suis toujours là » : répondez une fois, GRUP s’occupe du reste
-• 👥 Plusieurs groupes — famille, amis, équipe, club : tout est organisé
-• 📨 Invitations faciles — réunissez tout le monde avec une simple invitation
-• 🔔 Notifications — restez informé quand les plans changent
-• 🆓 Gratuit — pas de coûts cachés, pas de surprises
+• Calendrier partagé — tous les plans de votre groupe au même endroit
+• RSVP en un coup d’œil — voyez immédiatement qui vient et qui ne vient pas
+• Événements récurrents — dîner hebdomadaire, entraînement, soirée jeux : planifiez une seule fois
+• Réponses par défaut — « le mardi, je suis toujours là » : répondez une fois, GRUP s’occupe du reste
+• Plusieurs groupes — famille, amis, équipe, club : tout est organisé
+• Invitations faciles — réunissez tout le monde avec une simple invitation
+• Notifications — restez informé quand les plans changent
+• Gratuit — pas de coûts cachés, pas de surprises
 
 CONÇU POUR
 • Les familles — retrouvailles, dîners et organisation du quotidien

--- a/fastlane/metadata/ios/it/description.txt
+++ b/fastlane/metadata/ios/it/description.txt
@@ -3,14 +3,14 @@ Stanco di chat infinite su «quando va bene a tutti?» GRUP è il calendario con
 Crea un gruppo, condividi il calendario, pianifica un evento e raccogli le conferme in pochi secondi. Perfetto per famiglie con settimane piene, coppie che vogliono pianificare insieme e gruppi di amici che vogliono davvero vedersi di più.
 
 PERCHÉ GRUP?
-• 🗓️ Calendario condiviso — tutti i piani del tuo gruppo in un unico posto
-• ✅ Conferme a colpo d’occhio — vedi subito chi c’è e chi no
-• 🔁 Eventi ricorrenti — cena settimanale, allenamento, serata giochi: pianifichi una volta sola
-• ⭐ Risposte predefinite — «il martedì ci sono sempre»: rispondi una volta, al resto pensa GRUP
-• 👥 Più gruppi — famiglia, amici, squadra, club: tutto organizzato
-• 📨 Inviti facili — coinvolgi tutti con un semplice invito
-• 🔔 Notifiche — resta aggiornato quando i piani cambiano
-• 🆓 Gratis — nessun costo nascosto, nessuna sorpresa
+• Calendario condiviso — tutti i piani del tuo gruppo in un unico posto
+• Conferme a colpo d’occhio — vedi subito chi c’è e chi no
+• Eventi ricorrenti — cena settimanale, allenamento, serata giochi: pianifichi una volta sola
+• Risposte predefinite — «il martedì ci sono sempre»: rispondi una volta, al resto pensa GRUP
+• Più gruppi — famiglia, amici, squadra, club: tutto organizzato
+• Inviti facili — coinvolgi tutti con un semplice invito
+• Notifiche — resta aggiornato quando i piani cambiano
+• Gratis — nessun costo nascosto, nessuna sorpresa
 
 PENSATO PER
 • Famiglie — ritrovi, cene e organizzazione quotidiana


### PR DESCRIPTION
Second store-metadata failure on main: the ASC API rejects emoji in the `description` field ("An attribute value has invalid characters"). Emoji removed from `fastlane/metadata/ios/*/description.txt` in all five locales — the Play copies keep them, and the divergence is now documented in fastlane/README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)