### PR TITLE
fix(aso): pin App Store metadata sync to the pubspec version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,15 @@ platform :ios do
       issuer_id: ENV.fetch("ASC_ISSUER_ID"),
       key_content: ENV.fetch("ASC_KEY_CONTENT"),
     )
+    # Version-level metadata (release notes, promotional text) can only be
+    # written to an editable ("Prepare for Submission") version. Without
+    # app_version, deliver polls for one to appear and burns the job timeout
+    # whenever ASC has none (e.g. the previous version just went into review).
+    # Pinning the pubspec version makes deliver create the version if missing
+    # and fail fast with a real error otherwise.
+    pubspec_version = YAML.load_file("../pubspec.yaml")["version"].split("+").first
     upload_to_app_store(
+      app_version: pubspec_version,
       metadata_path: "./fastlane/metadata/ios",
       skip_binary_upload: true,
       skip_screenshots: true, # App Store screenshots are still managed in ASC directly


### PR DESCRIPTION
## Problem

The `app-store` job of the Store metadata workflow (run 31571366372) spent 15 minutes in deliver's `Cannot find edit app store version... Retrying` loop until the job timeout killed it.

deliver can only write version-level metadata (release notes, promotional text) to an **editable** ("Prepare for Submission") App Store version. The Aug 8 sync was green because iOS 1.7.2 sat editable in ASC; that version's state has since changed (submitted for review?), so ASC currently has no editable version and deliver polls forever — the lane never tells it which version it's shipping.

## Fix

Pass `app_version` (parsed from `pubspec.yaml`, currently `1.7.3`) to `upload_to_app_store`:

- **No editable version, nothing in review** (steady state after a release): deliver *creates* the version and stages the metadata + release notes — exactly what we want for the next release.
- **Editable version exists**: deliver aligns its version string and updates it.
- **A version is mid-review**: fails fast with a real ASC error instead of blind-polling to timeout.

Verified locally: lane CWD is `fastlane/` (so `../pubspec.yaml` resolves), YAML parse yields `1.7.3`, `fastlane lanes` parses clean. Merging this re-triggers the sync (workflow watches `fastlane/**`).

⚠️ Note: if ASC still holds an *editable* 1.7.2, this sync will rename it to 1.7.3 — desirable, since iOS 1.7.2 never shipped and Play is already on 1.7.3, but flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)